### PR TITLE
[BUGFIX] Saferpay JPY

### DIFF
--- a/src/Omnipay/Saferpay/Message/AuthorizeRequest.php
+++ b/src/Omnipay/Saferpay/Message/AuthorizeRequest.php
@@ -160,7 +160,7 @@ class AuthorizeRequest extends AbstractRequest
     {
         $data = array(
             'ACCOUNTID' => $this->getAccountId(),
-            'AMOUNT' => $this->getAmount() * 100,
+            'AMOUNT' => $this->getAmount() * (10 ** $this->getCurrencyDecimalPlaces()),
             'CURRENCY' => $this->getCurrency(),
             'ORDERID' => $this->getOrderId(),
             'SUCCESSLINK' => $this->getReturnUrl(),

--- a/tests/Omnipay/Saferpay/GatewayTest.php
+++ b/tests/Omnipay/Saferpay/GatewayTest.php
@@ -16,6 +16,24 @@ class GatewayTest extends GatewayTestCase
         $this->gateway = new Gateway($this->getHttpClient(), $this->getHttpRequest());
     }
 
+    public function testAuthorizeSuccessJPY(): void
+    {
+        $options = array(
+            'amount' => '10000',
+            'currency' => 'JPY',
+            'returnUrl' => 'https://www.example.com/return',
+            'cancelUrl' => 'https://www.example.com/cancel',
+        );
+
+        $this->setMockHttpResponse('AuthorizeSuccess.txt');
+
+        $this->gateway->authorize($options)->send();
+
+        foreach ($this->getMockedRequests() as $mockedRequest) {
+            $this->assertContains('AMOUNT=10000&', $mockedRequest->getUri()->getQuery());
+        }
+    }
+
     public function testAuthorizeSuccess(): void
     {
         $options = array(
@@ -28,6 +46,10 @@ class GatewayTest extends GatewayTestCase
 
         /** @var AuthorizeResponse $response */
         $response = $this->gateway->authorize($options)->send();
+
+        foreach ($this->getMockedRequests() as $mockedRequest) {
+            $this->assertContains('AMOUNT=1000&', $mockedRequest->getUri()->getQuery());
+        }
 
         $this->assertInstanceOf(AuthorizeResponse::class, $response);
         $this->assertFalse($response->isSuccessful());


### PR DESCRIPTION
https://www.six-payment-services.com/dam/saferpay/Saferpay_Payment_Page_EN.pdf tells:

Authorization amount in minor currency unit e.g. 1230 in EUR means EUR 12,30
The minor currency unit for JPY is 1 JPY => no need to multiply on 100 (like we do for EUR).