### PR TITLE
[FIX] getTransactionReference method for Sofort gateway

### DIFF
--- a/src/Omnipay/Sofort/Message/CompleteAuthorizeResponse.php
+++ b/src/Omnipay/Sofort/Message/CompleteAuthorizeResponse.php
@@ -11,4 +11,9 @@ class CompleteAuthorizeResponse extends Response implements RedirectResponseInte
         return isset($this->data->transaction_details) &&
             false === in_array($this->data->transaction_details->status, array('loss', 'refunded'));
     }
+
+    public function getTransactionReference()
+    {
+        return $this->data->transaction_details->transaction;
+    }
 }

--- a/tests/Omnipay/Sofort/GatewayTest.php
+++ b/tests/Omnipay/Sofort/GatewayTest.php
@@ -64,6 +64,7 @@ class GatewayTest extends GatewayTestCase
         $this->assertInstanceOf(CompleteAuthorizeResponse::class, $response);
         $this->assertTrue($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
+        $this->assertEquals('55742-165747-52441DAF-3596', $response->getTransactionReference());
     }
 
     public function testCompleteAuthorizeFailure()


### PR DESCRIPTION
As it is currently, getting transaction reference via Sofort gateway with `completeAuthorize` returns empty string. This manifests itself when creating a transactions for our orders-service, which leaves transaction reference information empty.

In order to enable this functionality and to align it with existing approach for new policy flow in the core app, I suggest to add this method to our Omnipay library.

Relate to JIRA ticket https://sisu-agile.atlassian.net/browse/CORE-5850